### PR TITLE
Remove disable SRAM2 and SRAM3 when awake.

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,8 +47,6 @@ pwr.disable_while_sleeping_all_but(
 # ADC needed to read system voltage
 
 pwr.disable_while_awake(
-    pwr.EN0_CLK_SYS_SRAM3,
-    pwr.EN0_CLK_SYS_SRAM2,
     pwr.EN0_CLK_SYS_SPI0,
     pwr.EN0_CLK_PERI_SPI0,
     pwr.EN0_CLK_SYS_SPI1,


### PR DESCRIPTION
That was a mistake on my part.
I was testing with a custom built micropython load that did not use these to SRAM banks.

If someone tried to run my code with a standard micropython interpreter it would crash.